### PR TITLE
Missing Properties in the DataDragonItemListDTO['data'] Interface

### DIFF
--- a/src/galeforce/interfaces/dto/lol-data-dragon/item-list.ts
+++ b/src/galeforce/interfaces/dto/lol-data-dragon/item-list.ts
@@ -167,6 +167,12 @@ interface Data {
         tags: string[];
         maps: Maps;
         stats: StatsOptional;
+        consumed?: boolean;
+        consumeOnFull?: boolean;
+        inStore?: boolean;
+        from?: string[];
+        requiredAlly?: string;
+        depth?: number;
     };
 }
 


### PR DESCRIPTION
Thank you for this awesome library.
I've noticed that some items have the properties `consumed`, `consumeOnFull`, `inStore`, `from`, `requiredAlly`, and `depth`.

For reference, please see: https://ddragon.leagueoflegends.com/cdn/13.8.1/data/en_US/item.json

- The item with key `4638` (Watchful Wardstone) has the `consumed` and `consumeOnFull` properties.
- The item with key `7014` (Eternal Winter) has the `inStore` property.
- The item with key `7026` (The Unspoken Parasite) has the `from`, `requiredAlly`, and `depth` properties.